### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of Topological Deep Learning (TDL) tools and resources.
 </p>
 
 3. **Shape Analysis**. Justin Solomon. [Website](http://groups.csail.mit.edu/gdpgroup/6838_spring_2021.html), [Lectures](https://www.youtube.com/playlist?list=PLQ3UicqQtfNtUcdTMLgKSTTOiEsCw2VBW)
+4. [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 <p align="center">
   <img width="200" height="200" src="http://groups.csail.mit.edu/gdpgroup/assets/research_thumbnails/teapot.png">

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ A curated list of Topological Deep Learning (TDL) tools and resources.
 </p>
 
 3. **Shape Analysis**. Justin Solomon. [Website](http://groups.csail.mit.edu/gdpgroup/6838_spring_2021.html), [Lectures](https://www.youtube.com/playlist?list=PLQ3UicqQtfNtUcdTMLgKSTTOiEsCw2VBW)
-4. [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+4. [TutorialSearch](https://tutorialsearch.io/?q=topological+deep) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 <p align="center">
   <img width="200" height="200" src="http://groups.csail.mit.edu/gdpgroup/assets/research_thumbnails/teapot.png">


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/?q=topological+deep) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/?q=topological+deep) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.